### PR TITLE
Add clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,3 +20,5 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Run clippy
+      run: cargo clippy

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # gitbom-rs
-"An experimental implementation of gitbom in Rust"
+"An experimental implementation of GitBOM in Rust"
+
+**NOTICE: This project is still a work in progress and is not ready for any use beyond experimental**
+
+## What is GitBOM?
+
+To quote [the GitBOM website](https://gitbom.dev/):
+
+```
+GitBOM is a minimalistic scheme for build tools to:
+1. Build a compact artifact tree, tracking every source code file incorporated into each build artifact
+2. Embed a unique, content addressable reference for that artifact tree, the GitBOM identifier, into the artifact at build time
+```
+
+For information, see [the website](https://gitbom.dev/) and the [list of GitBOM resources](https://gitbom.dev/resources/)
+
+## What is gitbom-rs?
+
+gitbom-rs is an experimental implementation of gitBOM in Rust. This is an important learning exercise and will inform future implementations of gitBOM in the future (both in Rust and in other languages)


### PR DESCRIPTION
[Clippy](https://github.com/rust-lang/rust-clippy) is a very useful Rust linting tool to keep the code consistent and readable (especially as new contributors join). This pull request adds Clippy to our CI so that it will run on every PR.