### PR TITLE
Refactor and add sha256

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,6 @@ categories = ["cryptography", "development-tools"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+base64ct = { version = "1.3.3", features = ["alloc"] } 
 sha1_smol = "1.0.0"
+sha2 = "0.10.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,13 @@ extern crate std;
 use alloc::format;
 use alloc::string::{String, ToString};
 use std::io::{BufReader, Read};
+use sha2::{Sha256, Digest};
+
+use base64ct::{Base64, Encoding};
 
 enum HashAlgorithm {
     SHA1,
-    SHA2
+    SHA256
 }
 
 struct GitOid {
@@ -15,14 +18,31 @@ struct GitOid {
 }
 
 impl GitOid {
-    pub fn generate_sha1_git_oid(&self, x: &[u8]) -> String {
+    pub fn generate_git_oid(&self, x: &[u8]) -> String {
         let prefix = format!("blob {}\0", x.len());
-        let mut hasher = sha1_smol::Sha1::new();
 
-        hasher.update(prefix.as_bytes());
-        hasher.update(x);
+        match self.hash_algorithm {
+            HashAlgorithm::SHA1 => {
+                let mut hasher = sha1_smol::Sha1::new();
 
-        hasher.digest().to_string()
+                hasher.update(prefix.as_bytes());
+                hasher.update(x);
+
+                hasher.digest().to_string()
+            },
+            HashAlgorithm::SHA256 => {
+                let mut hasher = Sha256::new();
+                hasher.update(x);
+
+                let hash = hasher.finalize();
+                println!("Binary hash: {:?}", hash);
+
+                let hash_string = Base64::encode_string(&hash);
+                println!("Base64-encoded hash: {}", hash_string);
+
+                return Base64::encode_string(&hash)
+            }
+        }
     }
 
     pub fn generate_sha1_git_oid_from_buffer<R>(
@@ -81,7 +101,7 @@ mod tests {
             hash_algorithm: HashAlgorithm::SHA1
         };
 
-        let result = new_gitoid.generate_sha1_git_oid(input);
+        let result = new_gitoid.generate_git_oid(input);
         assert_eq!(result, "95d09f2b10159347eece71399a7e2e907ea3df4f")
     }
 
@@ -93,7 +113,7 @@ mod tests {
                 let reader = BufReader::new(f);
 
                 let new_gitoid = GitOid {
-                    hash_algorithm: HashAlgorithm::SHA1
+                    hash_algorithm: HashAlgorithm::SHA256
                 };
 
                 let result = new_gitoid.generate_sha1_git_oid_from_buffer(reader, 11);
@@ -104,5 +124,18 @@ mod tests {
                 assert!(false)
             }
         }
+    }
+
+    #[test]
+    fn test_generate_sha2_git_oid() {
+        let input = "hello world".as_bytes();
+
+        let new_gitoid = GitOid {
+            hash_algorithm: HashAlgorithm::SHA256
+        };
+
+        let result = new_gitoid.generate_git_oid(input);
+
+        assert_eq!("uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=", result);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,15 +18,15 @@ struct GitOid {
 }
 
 impl GitOid {
-    pub fn generate_git_oid(&self, x: &[u8]) -> String {
-        let prefix = format!("blob {}\0", x.len());
+    pub fn generate_git_oid(&self, content: &[u8]) -> String {
+        let prefix = format!("blob {}\0", content.len());
 
         match self.hash_algorithm {
             HashAlgorithm::SHA1 => {
                 let mut hasher = sha1_smol::Sha1::new();
 
                 hasher.update(prefix.as_bytes());
-                hasher.update(x);
+                hasher.update(content);
 
                 hasher.digest().to_string()
             },
@@ -34,13 +34,10 @@ impl GitOid {
                 let mut hasher = Sha256::new();
 
                 hasher.update(prefix.as_bytes());
-                hasher.update(x);
+                hasher.update(content);
 
                 let hash = hasher.finalize();
-                println!("Binary hash: {:?}", hash);
-
                 let hash_string = Base64::encode_string(&hash);
-                println!("Base64-encoded hash: {}", hash_string);
 
                 return Base64::encode_string(&hash)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,8 @@ impl GitOid {
             },
             HashAlgorithm::SHA256 => {
                 let mut hasher = Sha256::new();
-                //TO DO - add in prefix
+
+                hasher.update(prefix.as_bytes());
                 hasher.update(x);
 
                 let hash = hasher.finalize();
@@ -85,7 +86,8 @@ impl GitOid {
             },
             HashAlgorithm::SHA256 => {
                 let mut hasher = Sha256::new();
-                //TO DO - add in prefix
+
+                hasher.update(prefix.as_bytes());
 
                 loop {
                     let y = reader.read(&mut buf);
@@ -169,7 +171,7 @@ mod tests {
 
         let result = new_gitoid.generate_git_oid(input);
 
-        assert_eq!("uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=", result);
+        assert_eq!("/uU6GNMoIGE8BSeqeb5cswFzyCOptEj6SBd2fMhMbwM=", result);
     }
 
     #[test]
@@ -185,7 +187,7 @@ mod tests {
 
                 let result = new_gitoid.generate_git_oid_from_buffer(reader, 11);
 
-                assert_eq!("uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=", result);
+                assert_eq!("/uU6GNMoIGE8BSeqeb5cswFzyCOptEj6SBd2fMhMbwM=", result);
             }
             Err(_) => {
                 assert!(false)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,47 +5,59 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use std::io::{BufReader, Read};
 
-pub fn generate_sha1_git_oid(x: &[u8]) -> String {
-    let prefix = format!("blob {}\0", x.len());
-    let mut hasher = sha1_smol::Sha1::new();
-
-    hasher.update(prefix.as_bytes());
-    hasher.update(x);
-
-    hasher.digest().to_string()
+enum HashAlgorithm {
+    SHA1,
+    SHA2
 }
 
-pub fn generate_sha1_git_oid_from_buffer<R>(
-    mut reader: BufReader<R>,
-    expected_length: usize,
-) -> String
-where
-    BufReader<R>: std::io::Read,
-{
-    let prefix = format!("blob {}\0", expected_length);
-    let mut hasher = sha1_smol::Sha1::new();
+struct GitOid {
+    hash_algorithm: HashAlgorithm,
+}
 
-    hasher.update(prefix.as_bytes());
+impl GitOid {
+    pub fn generate_sha1_git_oid(&self, x: &[u8]) -> String {
+        let prefix = format!("blob {}\0", x.len());
+        let mut hasher = sha1_smol::Sha1::new();
 
-    let mut buf = [0; 4096]; // linux default page size is 4096
-    let mut amount_read = 0;
-    loop {
-        let y = reader.read(&mut buf);
-        match y {
-            Ok(0) => {
-                break;
-            }
-            Ok(size) => {
-                hasher.update(&buf[..size]);
-                amount_read = amount_read + size;
-            }
-            Err(_) => {
-                break;
-            }
-        }
+        hasher.update(prefix.as_bytes());
+        hasher.update(x);
+
+        hasher.digest().to_string()
     }
 
-    hasher.digest().to_string()
+    pub fn generate_sha1_git_oid_from_buffer<R>(
+        &self,
+        mut reader: BufReader<R>,
+        expected_length: usize,
+    ) -> String
+    where
+        BufReader<R>: std::io::Read,
+    {
+        let prefix = format!("blob {}\0", expected_length);
+        let mut hasher = sha1_smol::Sha1::new();
+
+        hasher.update(prefix.as_bytes());
+
+        let mut buf = [0; 4096]; // linux default page size is 4096
+        let mut amount_read = 0;
+        loop {
+            let y = reader.read(&mut buf);
+            match y {
+                Ok(0) => {
+                    break;
+                }
+                Ok(size) => {
+                    hasher.update(&buf[..size]);
+                    amount_read = amount_read + size;
+                }
+                Err(_) => {
+                    break;
+                }
+            }
+        }
+
+        hasher.digest().to_string()
+    }
 }
 
 #[cfg(test)]
@@ -53,8 +65,7 @@ mod tests {
     use std::fs::File;
     use std::io::BufReader;
 
-    use crate::generate_sha1_git_oid;
-    use crate::generate_sha1_git_oid_from_buffer;
+    use super::*;
 
     #[test]
     fn it_works() {
@@ -66,7 +77,11 @@ mod tests {
     fn test_generate_sha1_git_oid() {
         let input = "hello world".as_bytes();
 
-        let result = generate_sha1_git_oid(input);
+        let new_gitoid = GitOid {
+            hash_algorithm: HashAlgorithm::SHA1
+        };
+
+        let result = new_gitoid.generate_sha1_git_oid(input);
         assert_eq!(result, "95d09f2b10159347eece71399a7e2e907ea3df4f")
     }
 
@@ -77,9 +92,13 @@ mod tests {
             Ok(f) => {
                 let reader = BufReader::new(f);
 
-                let hash = generate_sha1_git_oid_from_buffer(reader, 11);
+                let new_gitoid = GitOid {
+                    hash_algorithm: HashAlgorithm::SHA1
+                };
 
-                assert_eq!("95d09f2b10159347eece71399a7e2e907ea3df4f", hash)
+                let result = new_gitoid.generate_sha1_git_oid_from_buffer(reader, 11);
+
+                assert_eq!("95d09f2b10159347eece71399a7e2e907ea3df4f", result)
             }
             Err(_) => {
                 assert!(false)


### PR DESCRIPTION
This refactors the generation of gitoids, making it easier to add support for different hashing algorithms when we want to move beyond SHA1. I've also added some experimental support for SHA256 to demonstrate the ability to use different hashing algorithms.