### PR TITLE
synchronizes version numbers

### DIFF
--- a/gitbom/Cargo.toml
+++ b/gitbom/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "gitbom"
 readme = "../README.md"
 repository = "https://github.com/git-bom/gitbom-rs"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 gitoid = { path = "../gitoid" }

--- a/gitoid/Cargo.toml
+++ b/gitoid/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "gitoid"
 readme = "../README.md"
 repository = "https://github.com/git-bom/gitbom-rs"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 futures = "0.3.21"


### PR DESCRIPTION
gitbom already exists on crates.io as version 0.1.0.

We have made some significant changes to it. I have incremented the version number to 0.1.1. Although normally changes of this nature would require a major version increase, we are still pre-1.0.

Per the [semver spec](https://semver.org/):

```
Major version zero (0.y.z) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable
```

I would also like to keep the gitoid version number in sync with the gitbom version number for as long as possible. Therefore, I am starting that version number at 0.1.1 as well.

Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>