### PR TITLE
Further GitOid improvements

### DIFF
--- a/gitbom/Cargo.toml
+++ b/gitbom/Cargo.toml
@@ -12,11 +12,11 @@ version = "0.1.1"
 
 [dependencies]
 gitoid = "0.1.1"
-futures = "0.3.21"
+futures = "0.3.24"
 hex = "0.4.3"
-im = "15"
-pin-project = "1.0.10"
-sha1 = "0.10.1"
-sha2 = "0.10.2"
-tokio = {version = "1.17", features = ["io-util", "fs", "rt", "macros"]}
+im = "15.1.0"
+pin-project = "1.0.12"
+sha1 = "0.10.4"
+sha2 = "0.10.5"
+tokio = {version = "1.21.0", features = ["io-util", "fs", "rt", "macros"]}
 

--- a/gitbom/src/lib.rs
+++ b/gitbom/src/lib.rs
@@ -147,7 +147,7 @@ mod tests {
 
         assert_eq!(50, res.len());
         assert_eq!(
-            "SHA256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03",
+            "sha256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03",
             res[0].to_string()
         );
 

--- a/gitbom/src/lib.rs
+++ b/gitbom/src/lib.rs
@@ -80,14 +80,14 @@ impl GitBom {
 
 #[cfg(test)]
 mod tests {
-    use gitoid::{GitOid, HashAlgorithm};
+    use gitoid::{GitOid, HashAlgorithm, ObjectType};
     use im::vector;
 
     use super::*;
 
     #[test]
     fn test_add() {
-        let oid = GitOid::new_from_str(HashAlgorithm::SHA256, "Hello");
+        let oid = GitOid::new_from_str(HashAlgorithm::Sha256, ObjectType::Blob, "Hello");
         assert_eq!(GitBom::new().add(oid).get_sorted_oids(), vector![oid])
     }
 
@@ -95,7 +95,7 @@ mod tests {
     fn test_add_many() {
         let mut oids: Vector<GitOid> = vec!["eee", "Hello", "Cat", "Dog"]
             .into_iter()
-            .map(|s| GitOid::new_from_str(HashAlgorithm::SHA256, s))
+            .map(|s| GitOid::new_from_str(HashAlgorithm::Sha256, ObjectType::Blob, s))
             .collect();
 
         let da_bom = GitBom::new().add_many(oids.clone());
@@ -107,14 +107,15 @@ mod tests {
     fn test_add_gitoid_to_gitbom() {
         let input = "hello world".as_bytes();
 
-        let generated_gitoid = GitOid::new_from_bytes(HashAlgorithm::SHA256, input);
+        let generated_gitoid =
+            GitOid::new_from_bytes(HashAlgorithm::Sha256, ObjectType::Blob, input);
 
         let new_gitbom = GitBom::new();
         let new_gitbom = new_gitbom.add(generated_gitoid);
 
         assert_eq!(
             "fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03",
-            new_gitbom.get_sorted_oids()[0].hex_hash()
+            new_gitbom.get_sorted_oids()[0].hash()
         )
     }
 
@@ -133,9 +134,14 @@ mod tests {
         let mut res = Vec::new();
         for (reader, expected_length) in to_read {
             res.push(
-                GitOid::new_from_async_reader(HashAlgorithm::SHA256, reader, expected_length)
-                    .await
-                    .unwrap(),
+                GitOid::new_from_async_reader(
+                    HashAlgorithm::Sha256,
+                    ObjectType::Blob,
+                    reader,
+                    expected_length,
+                )
+                .await
+                .unwrap(),
             );
         }
 

--- a/gitbom/src/lib.rs
+++ b/gitbom/src/lib.rs
@@ -80,14 +80,14 @@ impl GitBom {
 
 #[cfg(test)]
 mod tests {
-    use gitoid::{GitOid, HashAlgorithm, ObjectType};
+    use gitoid::{GitOid, HashAlgorithm};
     use im::vector;
 
     use super::*;
 
     #[test]
     fn test_add() {
-        let oid = GitOid::new_from_str(HashAlgorithm::Sha256, ObjectType::Blob, "Hello");
+        let oid = GitOid::new_from_str(HashAlgorithm::SHA256, "Hello");
         assert_eq!(GitBom::new().add(oid).get_sorted_oids(), vector![oid])
     }
 
@@ -95,7 +95,7 @@ mod tests {
     fn test_add_many() {
         let mut oids: Vector<GitOid> = vec!["eee", "Hello", "Cat", "Dog"]
             .into_iter()
-            .map(|s| GitOid::new_from_str(HashAlgorithm::Sha256, ObjectType::Blob, s))
+            .map(|s| GitOid::new_from_str(HashAlgorithm::SHA256, s))
             .collect();
 
         let da_bom = GitBom::new().add_many(oids.clone());
@@ -107,15 +107,14 @@ mod tests {
     fn test_add_gitoid_to_gitbom() {
         let input = "hello world".as_bytes();
 
-        let generated_gitoid =
-            GitOid::new_from_bytes(HashAlgorithm::Sha256, ObjectType::Blob, input);
+        let generated_gitoid = GitOid::new_from_bytes(HashAlgorithm::SHA256, input);
 
         let new_gitbom = GitBom::new();
         let new_gitbom = new_gitbom.add(generated_gitoid);
 
         assert_eq!(
             "fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03",
-            new_gitbom.get_sorted_oids()[0].hash()
+            new_gitbom.get_sorted_oids()[0].hex_hash()
         )
     }
 
@@ -134,20 +133,15 @@ mod tests {
         let mut res = Vec::new();
         for (reader, expected_length) in to_read {
             res.push(
-                GitOid::new_from_async_reader(
-                    HashAlgorithm::Sha256,
-                    ObjectType::Blob,
-                    reader,
-                    expected_length,
-                )
-                .await
-                .unwrap(),
+                GitOid::new_from_async_reader(HashAlgorithm::SHA256, reader, expected_length)
+                    .await
+                    .unwrap(),
             );
         }
 
         assert_eq!(50, res.len());
         assert_eq!(
-            "sha256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03",
+            "SHA256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03",
             res[0].to_string()
         );
 

--- a/gitoid/Cargo.toml
+++ b/gitoid/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/git-bom/gitbom-rs"
 version = "0.1.1"
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.24"
 hex = "0.4.3"
-sha1 = "0.10.1"
-sha2 = "0.10.2"
-tokio = {version = "1.17", features = ["io-util", "fs", "rt", "macros"]}
+sha1 = "0.10.4"
+sha2 = "0.10.5"
+tokio = {version = "1.21.0", features = ["io-util", "fs", "rt", "macros"]}
 url = "2.2.2"

--- a/gitoid/Cargo.toml
+++ b/gitoid/Cargo.toml
@@ -16,4 +16,5 @@ hex = "0.4.3"
 sha1 = "0.10.1"
 sha2 = "0.10.2"
 tokio = {version = "1.17", features = ["io-util", "fs", "rt", "macros"]}
+url = "2.2.2"
 

--- a/gitoid/Cargo.toml
+++ b/gitoid/Cargo.toml
@@ -17,4 +17,3 @@ sha1 = "0.10.1"
 sha2 = "0.10.2"
 tokio = {version = "1.17", features = ["io-util", "fs", "rt", "macros"]}
 url = "2.2.2"
-

--- a/gitoid/src/builder.rs
+++ b/gitoid/src/builder.rs
@@ -1,0 +1,69 @@
+//! Easily construct `GitOid`s.
+
+use crate::{GitOid, HashAlgorithm, ObjectType, Result};
+use std::io::{BufReader, Read};
+use tokio::io::AsyncReadExt;
+
+/// Builder of GitOids with a specific hash algorithm and object type.
+pub struct GitOidBuilder {
+    /// The hash algorithm to use.
+    hash_algorithm: HashAlgorithm,
+
+    /// The object type to use.
+    object_type: ObjectType,
+}
+
+impl GitOidBuilder {
+    /// Get a new builder with a specific hash algorithm and object type.
+    pub fn new(hash_algorithm: HashAlgorithm, object_type: ObjectType) -> GitOidBuilder {
+        GitOidBuilder {
+            hash_algorithm,
+            object_type,
+        }
+    }
+
+    /// Build a `GitOid` from bytes.
+    pub fn build_from_bytes(&self, content: &[u8]) -> GitOid {
+        GitOid::new_from_bytes(self.hash_algorithm, self.object_type, content)
+    }
+
+    /// Build a `GitOid` from a string slice.
+    pub fn build_from_str(&self, s: &str) -> GitOid {
+        GitOid::new_from_str(self.hash_algorithm, self.object_type, s)
+    }
+
+    /// Build a `GitOid` from an arbitrary buffered reader.
+    pub fn build_from_reader<R>(
+        &self,
+        reader: BufReader<R>,
+        expected_length: usize,
+    ) -> Result<GitOid>
+    where
+        R: Read,
+    {
+        GitOid::new_from_reader(
+            self.hash_algorithm,
+            self.object_type,
+            reader,
+            expected_length,
+        )
+    }
+
+    /// Build a `GitOid` from an arbitrary asynchronous reader.
+    pub async fn build_from_async_reader<R>(
+        &self,
+        reader: R,
+        expected_length: usize,
+    ) -> Result<GitOid>
+    where
+        R: AsyncReadExt + Unpin,
+    {
+        GitOid::new_from_async_reader(
+            self.hash_algorithm,
+            self.object_type,
+            reader,
+            expected_length,
+        )
+        .await
+    }
+}

--- a/gitoid/src/error.rs
+++ b/gitoid/src/error.rs
@@ -3,12 +3,18 @@ use std::fmt::{self, Display, Formatter};
 use std::io::Error as IoError;
 use url::ParseError as UrlError;
 
-pub type Result<T> = std::result::Result<T, Error>;
+/// A `Result` with `gitoid::Error` as the error type.
+pub(crate) type Result<T> = std::result::Result<T, Error>;
 
+/// An error arising during `GitOid` construction or use.
 #[derive(Debug)]
 pub enum Error {
+    /// The expected and actual length of the data being read didn't
+    /// match, indicating something has likely gone wrong.
     BadLength { expected: usize, actual: usize },
+    /// Could not construct a valid URL based on the `GitOid` data.
     Url(UrlError),
+    /// Could not perform the IO operations necessary to construct the `GitOid`.
     Io(IoError),
 }
 

--- a/gitoid/src/error.rs
+++ b/gitoid/src/error.rs
@@ -1,0 +1,47 @@
+use std::error::Error as StdError;
+use std::fmt::{self, Display, Formatter};
+use std::io::Error as IoError;
+use url::ParseError as UrlError;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug)]
+pub enum Error {
+    BadLength { expected: usize, actual: usize },
+    Url(UrlError),
+    Io(IoError),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::BadLength { expected, actual } => {
+                write!(f, "expected length {}, actual length {}", expected, actual)
+            }
+            Error::Url(e) => write!(f, "{}", e),
+            Error::Io(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Error::BadLength { .. } => None,
+            Error::Url(e) => Some(e),
+            Error::Io(e) => Some(e),
+        }
+    }
+}
+
+impl From<UrlError> for Error {
+    fn from(e: UrlError) -> Error {
+        Error::Url(e)
+    }
+}
+
+impl From<IoError> for Error {
+    fn from(e: IoError) -> Error {
+        Error::Io(e)
+    }
+}

--- a/gitoid/src/gitoid.rs
+++ b/gitoid/src/gitoid.rs
@@ -4,12 +4,14 @@ use crate::{Error, HashAlgorithm, ObjectType, Result, NUM_HASH_BYTES};
 use core::fmt::{self, Display, Formatter};
 use core::marker::Unpin;
 use sha2::digest::DynDigest;
+use std::hash::Hash;
 use std::io::{BufReader, Read};
 use tokio::io::AsyncReadExt;
 use url::Url;
 
-/// A struct that computes [git oids](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects)
-/// based on the selected algorithm
+/// A struct that computes [gitoids][g] based on the selected algorithm
+///
+/// [g]: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
 #[derive(Clone, Copy, PartialOrd, Eq, Ord, Debug, Hash, PartialEq)]
 pub struct GitOid {
     /// The hash algorithm being used.
@@ -116,7 +118,7 @@ impl GitOid {
     // Getters
     //-------------------------------------------------------------------------------------------
 
-    /// Get a URL for the current gitoid.
+    /// Get a URL for the current `GitOid`.
     pub fn uri(&self) -> Result<Url> {
         let s = format!(
             "gitoid:{}:{}:{}",
@@ -127,7 +129,7 @@ impl GitOid {
         Ok(Url::parse(&s)?)
     }
 
-    /// Get the hex value of the hashcode, without the hash type.
+    /// Get the hex value of the hash data, without the hash type.
     pub fn hash(&self) -> String {
         hex::encode(self.bytes())
     }
@@ -136,7 +138,21 @@ impl GitOid {
     pub fn bytes(&self) -> &[u8] {
         &self.value[0..self.len]
     }
+
+    /// Get the hash algorithm used for the `GitOid`.
+    pub fn hash_algorithm(&self) -> HashAlgorithm {
+        self.hash_algorithm
+    }
+
+    /// Get the object type of the `GitOid`.
+    pub fn object_type(&self) -> ObjectType {
+        self.object_type
+    }
 }
+
+//===============================================================================================
+// Helpers
+//-----------------------------------------------------------------------------------------------
 
 /// The async version of generating a `GitOid` from a buffer
 async fn bytes_from_async_buffer<R>(

--- a/gitoid/src/gitoid.rs
+++ b/gitoid/src/gitoid.rs
@@ -77,7 +77,7 @@ impl GitOid {
         expected_length: usize,
     ) -> Result<Self>
     where
-        BufReader<R>: Read,
+        R: Read,
     {
         let digester = hash_algorithm.create_digester();
         let (len, value) = bytes_from_buffer(digester, reader, expected_length)?;

--- a/gitoid/src/hash_algorithm.rs
+++ b/gitoid/src/hash_algorithm.rs
@@ -8,9 +8,9 @@ use sha2::{digest::DynDigest, Digest, Sha256};
 #[derive(Clone, Copy, PartialOrd, Eq, Ord, Debug, Hash, PartialEq)]
 pub enum HashAlgorithm {
     /// [SHA1](https://en.wikipedia.org/wiki/SHA-1)
-    SHA1,
+    Sha1,
     /// [SHA256](https://en.wikipedia.org/wiki/SHA-2)
-    SHA256,
+    Sha256,
 }
 
 impl HashAlgorithm {
@@ -18,8 +18,8 @@ impl HashAlgorithm {
     /// a digester
     pub(crate) fn create_digester(&self) -> Box<dyn DynDigest> {
         match self {
-            HashAlgorithm::SHA1 => Box::new(Sha1::new()),
-            HashAlgorithm::SHA256 => Box::new(Sha256::new()),
+            HashAlgorithm::Sha1 => Box::new(Sha1::new()),
+            HashAlgorithm::Sha256 => Box::new(Sha256::new()),
         }
     }
 }
@@ -31,8 +31,8 @@ pub(crate) const NUM_HASH_BYTES: usize = 32;
 impl Display for HashAlgorithm {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
-            HashAlgorithm::SHA1 => write!(f, "SHA1"),
-            HashAlgorithm::SHA256 => write!(f, "SHA256"),
+            HashAlgorithm::Sha1 => write!(f, "SHA1"),
+            HashAlgorithm::Sha256 => write!(f, "SHA256"),
         }
     }
 }

--- a/gitoid/src/hash_algorithm.rs
+++ b/gitoid/src/hash_algorithm.rs
@@ -24,6 +24,9 @@ impl HashAlgorithm {
     }
 }
 
+// NOTE: This is kept here in this file because it needs to be updated
+//       if any new hash algorithms are added.
+
 /// The number of bytes required to store the largest hash. Currently 32 for SHA256
 /// If another `HashAlgorithm` is added, update to reflect.
 pub(crate) const NUM_HASH_BYTES: usize = 32;
@@ -31,8 +34,8 @@ pub(crate) const NUM_HASH_BYTES: usize = 32;
 impl Display for HashAlgorithm {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
-            HashAlgorithm::Sha1 => write!(f, "SHA1"),
-            HashAlgorithm::Sha256 => write!(f, "SHA256"),
+            HashAlgorithm::Sha1 => write!(f, "sha1"),
+            HashAlgorithm::Sha256 => write!(f, "sha256"),
         }
     }
 }

--- a/gitoid/src/lib.rs
+++ b/gitoid/src/lib.rs
@@ -1,9 +1,13 @@
 //! A content-addressable identity for a software artifact.
 
+mod error;
 mod gitoid;
 mod hash_algorithm;
+mod object_type;
 #[cfg(test)]
 mod tests;
 
+pub use crate::error::*;
 pub use crate::gitoid::*;
 pub use crate::hash_algorithm::*;
+pub use crate::object_type::ObjectType;

--- a/gitoid/src/lib.rs
+++ b/gitoid/src/lib.rs
@@ -1,5 +1,6 @@
 //! A content-addressable identity for a software artifact.
 
+mod builder;
 mod error;
 mod gitoid;
 mod hash_algorithm;
@@ -7,7 +8,8 @@ mod object_type;
 #[cfg(test)]
 mod tests;
 
+pub use crate::builder::*;
 pub use crate::error::*;
 pub use crate::gitoid::*;
 pub use crate::hash_algorithm::*;
-pub use crate::object_type::ObjectType;
+pub use crate::object_type::*;

--- a/gitoid/src/object_type.rs
+++ b/gitoid/src/object_type.rs
@@ -1,0 +1,29 @@
+use std::fmt::{self, Display, Formatter};
+
+/// The types of objects for which a `GitOid` can be made.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ObjectType {
+    /// An opaque git blob.
+    Blob,
+    /// A Git tree.
+    Tree,
+    /// A Git commit.
+    Commit,
+    /// A Git tag.
+    Tag,
+}
+
+impl Display for ObjectType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                ObjectType::Blob => "blob",
+                ObjectType::Tree => "tree",
+                ObjectType::Commit => "commit",
+                ObjectType::Tag => "tag",
+            }
+        )
+    }
+}

--- a/gitoid/src/tests.rs
+++ b/gitoid/src/tests.rs
@@ -1,18 +1,16 @@
 use super::*;
 use hash_algorithm::HashAlgorithm::*;
-use std::error::Error;
+use object_type::ObjectType::*;
 use std::fs::File;
 use std::io::BufReader;
-
-type Result<T> = std::result::Result<T, Box<dyn Error>>;
 
 #[test]
 fn generate_sha1_gitoid_from_bytes() {
     let input = b"hello world";
-    let result = GitOid::new_from_bytes(SHA1, input);
+    let result = GitOid::new_from_bytes(Sha1, Blob, input);
 
     assert_eq!(
-        result.hex_hash(),
+        result.hash(),
         "95d09f2b10159347eece71399a7e2e907ea3df4f"
     );
 
@@ -25,10 +23,10 @@ fn generate_sha1_gitoid_from_bytes() {
 #[test]
 fn generate_sha1_gitoid_from_buffer() -> Result<()> {
     let reader = BufReader::new(File::open("test/data/hello_world.txt")?);
-    let result = GitOid::new_from_reader(SHA1, reader, 11)?;
+    let result = GitOid::new_from_reader(Sha1, Blob, reader, 11)?;
 
     assert_eq!(
-        result.hex_hash(),
+        result.hash(),
         "95d09f2b10159347eece71399a7e2e907ea3df4f"
     );
 
@@ -45,7 +43,7 @@ async fn generate_sha1_gitoids_from_async_buffers() -> Result<()> {
     let reader = tokio::fs::File::open("test/data/hello_world.txt").await?;
     let expected_length = 11;
 
-    let res = GitOid::new_from_async_reader(SHA1, reader, expected_length).await?;
+    let res = GitOid::new_from_async_reader(Sha1, Blob, reader, expected_length).await?;
 
     assert_eq!(
         "SHA1:95d09f2b10159347eece71399a7e2e907ea3df4f",
@@ -58,10 +56,10 @@ async fn generate_sha1_gitoids_from_async_buffers() -> Result<()> {
 #[test]
 fn generate_sha256_gitoid_from_bytes() {
     let input = b"hello world";
-    let result = GitOid::new_from_bytes(SHA256, input);
+    let result = GitOid::new_from_bytes(Sha256, Blob, input);
 
     assert_eq!(
-        result.hex_hash(),
+        result.hash(),
         "fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03"
     );
 
@@ -74,10 +72,10 @@ fn generate_sha256_gitoid_from_bytes() {
 #[test]
 fn generate_sha256_gitoid_from_buffer() -> Result<()> {
     let reader = BufReader::new(File::open("test/data/hello_world.txt")?);
-    let result = GitOid::new_from_reader(SHA256, reader, 11)?;
+    let result = GitOid::new_from_reader(Sha256, Blob, reader, 11)?;
 
     assert_eq!(
-        result.hex_hash(),
+        result.hash(),
         "fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03"
     );
 
@@ -94,7 +92,7 @@ async fn generate_sha256_gitoids_from_async_buffers() -> Result<()> {
     let reader = tokio::fs::File::open("test/data/hello_world.txt").await?;
     let expected_length = 11;
 
-    let res = GitOid::new_from_async_reader(SHA256, reader, expected_length).await?;
+    let res = GitOid::new_from_async_reader(Sha256, Blob, reader, expected_length).await?;
 
     assert_eq!(
         "SHA256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03",

--- a/gitoid/src/tests.rs
+++ b/gitoid/src/tests.rs
@@ -9,14 +9,11 @@ fn generate_sha1_gitoid_from_bytes() {
     let input = b"hello world";
     let result = GitOid::new_from_bytes(Sha1, Blob, input);
 
-    assert_eq!(
-        result.hash(),
-        "95d09f2b10159347eece71399a7e2e907ea3df4f"
-    );
+    assert_eq!(result.hash(), "95d09f2b10159347eece71399a7e2e907ea3df4f");
 
     assert_eq!(
         result.to_string(),
-        "SHA1:95d09f2b10159347eece71399a7e2e907ea3df4f"
+        "sha1:95d09f2b10159347eece71399a7e2e907ea3df4f"
     );
 }
 
@@ -25,14 +22,11 @@ fn generate_sha1_gitoid_from_buffer() -> Result<()> {
     let reader = BufReader::new(File::open("test/data/hello_world.txt")?);
     let result = GitOid::new_from_reader(Sha1, Blob, reader, 11)?;
 
-    assert_eq!(
-        result.hash(),
-        "95d09f2b10159347eece71399a7e2e907ea3df4f"
-    );
+    assert_eq!(result.hash(), "95d09f2b10159347eece71399a7e2e907ea3df4f");
 
     assert_eq!(
         result.to_string(),
-        "SHA1:95d09f2b10159347eece71399a7e2e907ea3df4f"
+        "sha1:95d09f2b10159347eece71399a7e2e907ea3df4f"
     );
 
     Ok(())
@@ -46,7 +40,7 @@ async fn generate_sha1_gitoids_from_async_buffers() -> Result<()> {
     let res = GitOid::new_from_async_reader(Sha1, Blob, reader, expected_length).await?;
 
     assert_eq!(
-        "SHA1:95d09f2b10159347eece71399a7e2e907ea3df4f",
+        "sha1:95d09f2b10159347eece71399a7e2e907ea3df4f",
         res.to_string()
     );
 
@@ -65,7 +59,7 @@ fn generate_sha256_gitoid_from_bytes() {
 
     assert_eq!(
         result.to_string(),
-        "SHA256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03"
+        "sha256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03"
     );
 }
 
@@ -81,7 +75,7 @@ fn generate_sha256_gitoid_from_buffer() -> Result<()> {
 
     assert_eq!(
         result.to_string(),
-        "SHA256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03"
+        "sha256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03"
     );
 
     Ok(())
@@ -95,8 +89,21 @@ async fn generate_sha256_gitoids_from_async_buffers() -> Result<()> {
     let res = GitOid::new_from_async_reader(Sha256, Blob, reader, expected_length).await?;
 
     assert_eq!(
-        "SHA256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03",
+        "sha256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03",
         res.to_string()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn validate_uri() -> Result<()> {
+    let content = b"hello world";
+    let gitoid = GitOid::new_from_bytes(Sha256, Blob, content);
+
+    assert_eq!(
+        gitoid.uri()?.to_string(),
+        "gitoid:blob:sha256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03"
     );
 
     Ok(())


### PR DESCRIPTION
These commits do a few things.

1. Bump the dependency versions to their latest.
2. Introduce an `ObjectType` enum and make it a parameter of all the `GitOid` constructors.
3. Rename the `HashAlgorithm` variants to `Sha1` and `Sha256`, so the capitalization matches regular Rust style.
4. Introduce a `GitOidBuilder` type to make constructing many `GitOid`s with the same configuration easier.
5. Modify the trait bound on `GitOid::new_from_reader` from `BufReader<R>: Read` to `R: Read`.

On the second item: for the `gitbom` crate I believe we only care about the `ObjectType::Blob` variant, but the `gitoid` crate might have other users who want to handle other types of Git objects.

On the builder, this is the simplest-possible builder at the moment; the configuration is only set in the constructor of the builder, and can't be changed after that. It may be worth adding setters and getters for the configuration, but that hasn't been done here.
