### PR TITLE
Introduce a separate Hash struct.

### DIFF
--- a/gitoid/src/gitoid.rs
+++ b/gitoid/src/gitoid.rs
@@ -1,10 +1,10 @@
 //! A gitoid representing a single artifact.
 
-use crate::{Error, Hash, HashAlgorithm, ObjectType, Result, NUM_HASH_BYTES};
+use crate::{Error, HashAlgorithm, HashRef, ObjectType, Result, NUM_HASH_BYTES};
 use core::fmt::{self, Display, Formatter};
 use core::marker::Unpin;
 use sha2::digest::DynDigest;
-use std::hash::Hash as StdHash;
+use std::hash::Hash;
 use std::io::{BufReader, Read};
 use tokio::io::AsyncReadExt;
 use url::Url;
@@ -12,7 +12,7 @@ use url::Url;
 /// A struct that computes [gitoids][g] based on the selected algorithm
 ///
 /// [g]: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
-#[derive(Clone, Copy, PartialOrd, Eq, Ord, Debug, StdHash, PartialEq)]
+#[derive(Clone, Copy, PartialOrd, Eq, Ord, Debug, Hash, PartialEq)]
 pub struct GitOid {
     /// The hash algorithm being used.
     hash_algorithm: HashAlgorithm,
@@ -130,8 +130,8 @@ impl GitOid {
     }
 
     /// Get the hash data as a slice of bytes.
-    pub fn hash(&self) -> Hash<'_> {
-        Hash::new(&self.value[0..self.len])
+    pub fn hash(&self) -> HashRef<'_> {
+        HashRef::new(&self.value[0..self.len])
     }
 
     /// Get the hash algorithm used for the `GitOid`.

--- a/gitoid/src/gitoid.rs
+++ b/gitoid/src/gitoid.rs
@@ -1,10 +1,10 @@
 //! A gitoid representing a single artifact.
 
-use crate::{Error, HashAlgorithm, ObjectType, Result, NUM_HASH_BYTES};
+use crate::{Error, Hash, HashAlgorithm, ObjectType, Result, NUM_HASH_BYTES};
 use core::fmt::{self, Display, Formatter};
 use core::marker::Unpin;
 use sha2::digest::DynDigest;
-use std::hash::Hash;
+use std::hash::Hash as StdHash;
 use std::io::{BufReader, Read};
 use tokio::io::AsyncReadExt;
 use url::Url;
@@ -12,7 +12,7 @@ use url::Url;
 /// A struct that computes [gitoids][g] based on the selected algorithm
 ///
 /// [g]: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
-#[derive(Clone, Copy, PartialOrd, Eq, Ord, Debug, Hash, PartialEq)]
+#[derive(Clone, Copy, PartialOrd, Eq, Ord, Debug, StdHash, PartialEq)]
 pub struct GitOid {
     /// The hash algorithm being used.
     hash_algorithm: HashAlgorithm,
@@ -129,14 +129,9 @@ impl GitOid {
         Ok(Url::parse(&s)?)
     }
 
-    /// Get the hex value of the hash data, without the hash type.
-    pub fn hash(&self) -> String {
-        hex::encode(self.bytes())
-    }
-
     /// Get the hash data as a slice of bytes.
-    pub fn bytes(&self) -> &[u8] {
-        &self.value[0..self.len]
+    pub fn hash(&self) -> Hash<'_> {
+        Hash::new(&self.value[0..self.len])
     }
 
     /// Get the hash algorithm used for the `GitOid`.

--- a/gitoid/src/hash.rs
+++ b/gitoid/src/hash.rs
@@ -1,0 +1,40 @@
+//! Provides a type for representing the hash contained inside a `GitOid`.
+
+use std::fmt::{self, Display, Formatter};
+use std::ops::Deref;
+
+/// The hash produced for a `GitOid`
+pub struct Hash<'h>(&'h [u8]);
+
+impl<'h> Hash<'h> {
+    /// Construct a new `Hash` for the given bytes.
+    pub fn new(bytes: &[u8]) -> Hash<'_> {
+        Hash(bytes)
+    }
+
+    /// Get the hash as a slice of bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0
+    }
+
+    /// Get a hexadecimal-encoded representation of the hash.
+    pub fn as_hex(&self) -> String {
+        hex::encode(self.0)
+    }
+}
+
+// Deref to a slice of bytes.
+impl<'h> Deref for Hash<'h> {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+// Print as the hex encoding.
+impl<'h> Display for Hash<'h> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_hex())
+    }
+}

--- a/gitoid/src/hash.rs
+++ b/gitoid/src/hash.rs
@@ -5,12 +5,12 @@ use std::ops::Deref;
 
 /// The hash produced for a `GitOid`
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct Hash<'h>(&'h [u8]);
+pub struct HashRef<'h>(&'h [u8]);
 
-impl<'h> Hash<'h> {
+impl<'h> HashRef<'h> {
     /// Construct a new `Hash` for the given bytes.
-    pub fn new(bytes: &[u8]) -> Hash<'_> {
-        Hash(bytes)
+    pub fn new(bytes: &[u8]) -> HashRef<'_> {
+        HashRef(bytes)
     }
 
     /// Get the hash as a slice of bytes.
@@ -25,7 +25,7 @@ impl<'h> Hash<'h> {
 }
 
 // Deref to a slice of bytes.
-impl<'h> Deref for Hash<'h> {
+impl<'h> Deref for HashRef<'h> {
     type Target = [u8];
 
     fn deref(&self) -> &[u8] {
@@ -34,7 +34,7 @@ impl<'h> Deref for Hash<'h> {
 }
 
 // Print as the hex encoding.
-impl<'h> Display for Hash<'h> {
+impl<'h> Display for HashRef<'h> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.as_hex())
     }

--- a/gitoid/src/hash.rs
+++ b/gitoid/src/hash.rs
@@ -4,6 +4,7 @@ use std::fmt::{self, Display, Formatter};
 use std::ops::Deref;
 
 /// The hash produced for a `GitOid`
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Hash<'h>(&'h [u8]);
 
 impl<'h> Hash<'h> {

--- a/gitoid/src/lib.rs
+++ b/gitoid/src/lib.rs
@@ -3,6 +3,7 @@
 mod builder;
 mod error;
 mod gitoid;
+mod hash;
 mod hash_algorithm;
 mod object_type;
 #[cfg(test)]
@@ -11,5 +12,6 @@ mod tests;
 pub use crate::builder::*;
 pub use crate::error::*;
 pub use crate::gitoid::*;
+pub use crate::hash::*;
 pub use crate::hash_algorithm::*;
 pub use crate::object_type::*;

--- a/gitoid/src/tests.rs
+++ b/gitoid/src/tests.rs
@@ -9,7 +9,10 @@ fn generate_sha1_gitoid_from_bytes() {
     let input = b"hello world";
     let result = GitOid::new_from_bytes(Sha1, Blob, input);
 
-    assert_eq!(result.hash(), "95d09f2b10159347eece71399a7e2e907ea3df4f");
+    assert_eq!(
+        result.hash().as_hex(),
+        "95d09f2b10159347eece71399a7e2e907ea3df4f"
+    );
 
     assert_eq!(
         result.to_string(),
@@ -22,7 +25,10 @@ fn generate_sha1_gitoid_from_buffer() -> Result<()> {
     let reader = BufReader::new(File::open("test/data/hello_world.txt")?);
     let result = GitOid::new_from_reader(Sha1, Blob, reader, 11)?;
 
-    assert_eq!(result.hash(), "95d09f2b10159347eece71399a7e2e907ea3df4f");
+    assert_eq!(
+        result.hash().as_hex(),
+        "95d09f2b10159347eece71399a7e2e907ea3df4f"
+    );
 
     assert_eq!(
         result.to_string(),
@@ -53,7 +59,7 @@ fn generate_sha256_gitoid_from_bytes() {
     let result = GitOid::new_from_bytes(Sha256, Blob, input);
 
     assert_eq!(
-        result.hash(),
+        result.hash().as_hex(),
         "fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03"
     );
 
@@ -69,7 +75,7 @@ fn generate_sha256_gitoid_from_buffer() -> Result<()> {
     let result = GitOid::new_from_reader(Sha256, Blob, reader, 11)?;
 
     assert_eq!(
-        result.hash(),
+        result.hash().as_hex(),
         "fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03"
     );
 


### PR DESCRIPTION
This is intended to make the API clearer in separating the hash, which is part of the `GitOid` but not sufficient for representing the `GitOid`, from the overall `GitOid` structure. The `GitOid` can be represented as a URI, or you can extract the parts (hash algorithm, object type, hash) individually. If you have the `Hash`, now represented as a struct, you can either access the individual bytes through the `Deref` impl or `as_bytes` method, or you can get the hexadecimal encoding through the `Display` impl or the implied `to_string` method or explicit `hex` method.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>